### PR TITLE
Don't add same message twice on unsubscribe view

### DIFF
--- a/newsfeed/views.py
+++ b/newsfeed/views.py
@@ -132,13 +132,11 @@ class NewsletterUnsubscribeView(SubscriptionAjaxResponseMixin):
             self.message = (
                 'You have successfully unsubscribed from the newsletter.'
             )
-            messages.success(self.request, self.message)
         else:
             self.success = False
             self.message = (
                 'Subscriber with this e-mail address does not exist.'
             )
-            messages.error(self.request, self.message)
 
         return super().form_valid(form)
 


### PR DESCRIPTION
Do not add the same message twice through the Django messages framework.

The message was already being added through ``SubscriptionAjaxResponseMixin``

https://github.com/saadmk11/django-newsfeed/blob/3c8771bcfa3735a422d4d9856f54c687093ff642/newsfeed/views.py#L72

This caused a bug that would show that same message multiple times in the template.
